### PR TITLE
Add gpu test run command to the CI script

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -22,6 +22,7 @@ test_job:
     - cd /sparse_accumulation
     - python3 -m pip install . --user
     - python3 -m pytest tests/test_cpp_contiguous.py
+    - python3 -m pytest tests/test_cpp_jit_cuda.py -vrA
   variables:
     SLURM_JOB_NUM_NODES: 1
     SLURM_PARTITION: normal


### PR DESCRIPTION
Until now only the `test_cpp_contiguous.py` test was running on the CI. Now the GPU one would run as well. Hopefully.